### PR TITLE
Dll loading is moved out of constructor

### DIFF
--- a/Buffer.cpp
+++ b/Buffer.cpp
@@ -12,7 +12,7 @@ Buffer::Buffer(const size_t defaultRowNum, const size_t defaultRowLength)  // co
     {
         throw std::runtime_error("(Exception at buffer constructor) Number of rows or row length is too small(must be >0)\n");
     }
-    if (defaultRowLength > INT_MAX - 100 || defaultRowLength > INT_MAX - 100)
+    if (defaultRowLength > INT_MAX - 100 || defaultRowNum > INT_MAX - 100)
     {
         throw std::runtime_error("(Exception at buffer constructor) Number of rows and/or columns is too big\n");
     }

--- a/CaesarCipher.cpp
+++ b/CaesarCipher.cpp
@@ -53,9 +53,16 @@ int CaesarCipher::EncryptTxt(const int key, std::string fromPath, std::string to
 	std::fstream fileTo;
 
 	fileFrom.open(fromPath, std::ios::binary);
-	fileTo.open(toPath, std::ios::out | std::ios::trunc);
 	
-	if(!fileTo.is_open() || !fileFrom.is_open())
+	if(!fileFrom.is_open())
+	{
+		printf("Could not open the file\n");
+		return -1;
+	}
+	
+	fileTo.open(toPath, std::ios::out | std::ios::trunc);
+
+	if (!fileTo.is_open())
 	{
 		printf("Could not open the file\n");
 		return -1;
@@ -108,9 +115,16 @@ int CaesarCipher::DecryptTxt(const int key, std::string fromPath, std::string to
 	std::fstream fileTo;
 
 	fileFrom.open(fromPath, std::ios::binary);
+
+	if (!fileFrom.is_open())
+	{
+		printf("Could not open the file\n");
+		return -1;
+	}
+
 	fileTo.open(toPath, std::ios::out | std::ios::trunc);
 
-	if (!fileTo.is_open() || !fileFrom.is_open())
+	if (!fileTo.is_open())
 	{
 		printf("Could not open the file\n");
 		return -1;

--- a/TextEditor.cpp
+++ b/TextEditor.cpp
@@ -1,8 +1,5 @@
-
-//#include "Buffer.h"
 #include <windows.h>
 #include <new>
-
 #include "CommandEnum.h"
 #include "CaesarCipher.h"
 #include "TextEditor.h"
@@ -24,8 +21,8 @@ TextEditor::TextEditor(const size_t rowNum, const size_t rowLength, const char* 
         if (buffer != nullptr)
         {
             delete buffer;
-        }
-		printf(er.what());
+        } 
+		printf(er.what());  // TO DO: add an if which would ensure that the program runs without dll 
     }
 }
 
@@ -514,9 +511,5 @@ int TextEditor::HandleCipherTxtAction(char* input, size_t inputSize)
     return -1;
  
 }
-
-
-//
-// BUFFFER LOGIC 
-//				 
+		 
 

--- a/TextEditor.cpp
+++ b/TextEditor.cpp
@@ -10,11 +10,10 @@
 
 TextEditor::TextEditor(const size_t rowNum, const size_t rowLength, const char* pathToDll)
 {
-    std::string dllPath = std::string(pathToDll);
+    this->pathToDll = std::string(pathToDll);
     try
     {
-        buffer = new Buffer(rowNum, rowLength);
-        caesarCipher = new CaesarCipher(dllPath);
+		buffer = new Buffer(rowNum, rowLength);
     }
     catch (const std::runtime_error& er)
     {
@@ -22,7 +21,9 @@ TextEditor::TextEditor(const size_t rowNum, const size_t rowLength, const char* 
         {
             delete buffer;
         } 
-		printf(er.what());  // TO DO: add an if which would ensure that the program runs without dll 
+		printf(er.what());  // TO DO: add an if which would ensure that the program runs without dll
+		Sleep(1000);
+		exit(1);
     }
 }
 
@@ -32,6 +33,7 @@ TextEditor::~TextEditor()
     delete caesarCipher;
     filePtr = nullptr;
 	delete buffer;
+	buffer = nullptr;
 }
 
 void TextEditor::ExecuteCommand(enum Mode command, bool* ifContinue)
@@ -116,6 +118,7 @@ void TextEditor::HandleUserExit(char* input)
 	input = nullptr;
 
 	delete this;
+
 
 	Sleep(100);
 	exit(0);
@@ -432,6 +435,20 @@ int TextEditor::HandleCipherTxtAction(char* input, size_t inputSize)
 {
     int	 key = 0;
 	char ifEncrypt;
+	if (!ifLibLoaded)
+	{
+		try
+		{
+			caesarCipher = new CaesarCipher(pathToDll);
+		}
+		catch (const std::runtime_error& er)
+		{
+			printf(er.what());
+			return -1;
+		}
+	}
+	
+	ifLibLoaded = true;
 
     printf("Enter the filepath for FROM file: ");
     fgets(input, static_cast<int>(inputSize), stdin);
@@ -512,4 +529,11 @@ int TextEditor::HandleCipherTxtAction(char* input, size_t inputSize)
  
 }
 		 
-
+std::string TextEditor::GetDllPath()
+{
+	return pathToDll;
+}
+void TextEditor::SetDllPath(std::string pathToDll)
+{
+	this->pathToDll = pathToDll;
+}

--- a/TextEditor.h
+++ b/TextEditor.h
@@ -1,6 +1,6 @@
-
 #ifndef _TEXT_EDITOR_CLI_H_
 #define _TEXT_EDITOR_CLI_H_
+
 #include <stdio.h>
 #include <stdlib.h>
 #include "CaesarCipher.h"

--- a/TextEditor.h
+++ b/TextEditor.h
@@ -5,6 +5,7 @@
 #include <stdlib.h>
 #include "CaesarCipher.h"
 #include "Buffer.h"
+#include "string"
 
 
 class TextEditor
@@ -31,17 +32,15 @@ private:
     int HandleCut();
     int HandleCopy();
     int HandleCipherTxtAction(char* input, size_t inputSize);
-    
-
     int HandlePaste();
-    
+    void SetDllPath(std::string);
+    std::string GetDllPath();
+
+    std::string pathToDll = "";
+    bool ifLibLoaded = false;
     CaesarCipher* caesarCipher = nullptr;
     Buffer* buffer = nullptr;
-    
     FILE* filePtr = nullptr;
-    // common functions
-
-
 };
 
 


### PR DESCRIPTION
The dll loading happens in HandleCipherTxtAction()` if it was not loaded before
The app is able to function without the dll